### PR TITLE
Add API to documentation

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -15,3 +15,9 @@ html:
   use_edit_page_button  : true
   use_repository_button : true
   use_issues_button     : true
+
+sphinx:
+  extra_extensions          : ['sphinx.ext.autodoc', 'sphinx.ext.mathjax',
+                               'sphinx.ext.viewcode', 'sphinx.ext.napoleon',
+                               'alabaster']   # A list of extra extensions to load by Sphinx.
+  config                    :   # key-value pairs to directly over-ride the Sphinx configuration

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -8,3 +8,6 @@
     - file: gini
     - file: income_measures
     - file: weighting
+- file: api/api
+  sections:
+  - file: api/agg

--- a/docs/api/agg.rst
+++ b/docs/api/agg.rst
@@ -1,9 +1,9 @@
 .. _agg:
 
-`microdf` aggregation functions
+microdf aggregation functions
 =================================================
 
-**`microdf` aggregation functions**
+**microdf aggregation functions**
 
 microdf.agg
 ------------------------------------------

--- a/docs/api/agg.rst
+++ b/docs/api/agg.rst
@@ -1,0 +1,14 @@
+.. _agg:
+
+`microdf` aggregation functions
+=================================================
+
+**`microdf` aggregation functions**
+
+microdf.agg
+------------------------------------------
+
+.. currentmodule:: microdf.agg
+
+.. automodule:: microdf.agg
+  :members: combine_base_reform, pctchg_base_reform, agg

--- a/docs/api/api.rst
+++ b/docs/api/api.rst
@@ -1,0 +1,12 @@
+`microdf` API
+=============
+
+Here we provide a view of the `microdf` API with links to the source code.
+Below is a list of the `microdf` package modules (in alphabetical order) with
+documentation about how to call each function.
+There is also a link to the source code for each documented member.
+
+.. toctree::
+   :maxdepth: 1
+
+   agg

--- a/docs/api/api.rst
+++ b/docs/api/api.rst
@@ -1,8 +1,8 @@
-`microdf` API
+microdf API
 =============
 
-Here we provide a view of the `microdf` API with links to the source code.
-Below is a list of the `microdf` package modules (in alphabetical order) with
+Here we provide a view of the microdf API with links to the source code.
+Below is a list of the microdf package modules (in alphabetical order) with
 documentation about how to call each function.
 There is also a link to the source code for each documented member.
 


### PR DESCRIPTION
Fixes #114 

I started by modeling after https://github.com/PSLmodels/Tax-Calculator/pull/2441, testing with a single page (`agg.py`). However, `jb build .` throws the following error:
```
(base) mghenis@penguin:~/PSLmodels/microdf/docs$ jb build .
Running Jupyter-Book v0.8.0
Traceback (most recent call last):
  File "/home/mghenis/anaconda3/bin/jb", line 8, in <module>
    sys.exit(main())
  File "/home/mghenis/anaconda3/lib/python3.7/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/home/mghenis/anaconda3/lib/python3.7/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/home/mghenis/anaconda3/lib/python3.7/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/mghenis/anaconda3/lib/python3.7/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/mghenis/anaconda3/lib/python3.7/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/mghenis/anaconda3/lib/python3.7/site-packages/jupyter_book/commands/__init__.py", line 199, in build
    build_modified = max([os.stat(ii).st_mtime for ii in build_files])
ValueError: max() arg is an empty sequence
```

@jdebacker could you please take a look to see if I got anything obviously wrong here, or could you recommend documentation on making this work? I didn't see this error in the `executable-books` org. Maybe `microdf.agg` isn't a proper module?