### PR TITLE
Add poverty functions

### DIFF
--- a/microdf/__init__.py
+++ b/microdf/__init__.py
@@ -37,7 +37,13 @@ from .inequality import (
     top_x_pct_share,
 )
 from .io import read_stata_zip
-from .poverty import fpl
+from .poverty import (
+    fpl,
+    poverty_rate,
+    deep_poverty_rate,
+    poverty_gap,
+    squared_poverty_gap,
+)
 from .style import AXIS_COLOR, DPI, GRID_COLOR, TITLE_COLOR, set_plot_style
 from .tax import mtr, tax_from_mtrs
 from .taxcalc import (

--- a/microdf/__init__.py
+++ b/microdf/__init__.py
@@ -124,6 +124,10 @@ __all__ = [
     "read_stata_zip",
     # poverty.py
     "fpl",
+    "poverty_rate",
+    "deep_poverty_rate",
+    "poverty_gap",
+    "squared_poverty_gap",
     # style.py
     "AXIS_COLOR",
     "DPI",

--- a/microdf/poverty.py
+++ b/microdf/poverty.py
@@ -1,4 +1,8 @@
-def fpl(people):
+import numpy as np
+import pandas as pd
+
+
+def fpl(people: int):
     """Calculates the federal poverty guideline for a household of a certain
        size.
 
@@ -9,3 +13,101 @@ def fpl(people):
 
     """
     return 7820 + 4320 * people
+
+
+def poverty_rate(
+    df: pd.DataFrame, income: str, threshold: str, w: str = None
+) -> float:
+    """Calculate poverty rate, i.e., the population share with income
+       below their poverty threshold.
+
+    :param df: DataFrame with income, threshold, and possibly weight columns
+        for each person/household.
+    :type df: pd.DataFrame
+    :param income: Column indicating income.
+    :type income: str
+    :param threshold: Column indicating threshold.
+    :type threshold: str
+    :param w: Column indicating weight, defaults to None (unweighted).
+    :type w: str, optional
+    :return: Poverty rate between zero and one.
+    :rtype: float
+    """
+    pov = df[income] < df[threshold]
+    if w is None:
+        return pov.mean()
+    return (pov * w).sum() / w.sum()
+
+
+def deep_poverty_rate(
+    df: pd.DataFrame, income: str, threshold: str, w: str = None
+) -> float:
+    """Calculate deep poverty rate, i.e., the population share with income
+       below half their poverty threshold.
+
+    :param df: DataFrame with income, threshold, and possibly weight columns
+        for each person/household.
+    :type df: pd.DataFrame
+    :param income: Column indicating income.
+    :type income: str
+    :param threshold: Column indicating threshold.
+    :type threshold: str
+    :param w: Column indicating weight, defaults to None (unweighted).
+    :type w: str, optional
+    :return: Deep poverty rate between zero and one.
+    :rtype: float
+    """
+    pov = df[income] < df[threshold] / 2
+    if w is None:
+        return pov.mean()
+    return (pov * w).sum() / w.sum()
+
+
+def poverty_gap(
+    df: pd.DataFrame, income: str, threshold: str, w: str = None
+) -> float:
+    """Calculate poverty gap, i.e., the total gap between income and poverty
+       thresholds for all people in poverty.
+
+    :param df: DataFrame with income, threshold, and possibly weight columns
+        for each household (data should represent households, not persons).
+    :type df: pd.DataFrame
+    :param income: Column indicating income.
+    :type income: str
+    :param threshold: Column indicating threshold.
+    :type threshold: str
+    :param w: Column indicating weight, defaults to None (unweighted).
+    :type w: str, optional
+    :return: Poverty gap.
+    :rtype: float
+    """
+    gap = np.maximum(df[threshold] - df[income], 0)
+    if w is None:
+        return gap.sum()
+    return (gap * df[w]).sum()
+
+
+def squared_poverty_gap(
+    df: pd.DataFrame, income: str, threshold: str, w: str = None
+) -> float:
+    """Calculate squared poverty gap, i.e., the total squared gap between
+       income and poverty thresholds for all people in poverty.
+       Also known as poverty severity index.
+
+    :param df: DataFrame with income, threshold, and possibly weight columns
+        for each household (data should represent households, not persons).
+    :type df: pd.DataFrame
+    :param income: Column indicating income.
+    :type income: str
+    :param threshold: Column indicating threshold.
+    :type threshold: str
+    :param w: Column indicating weight, defaults to None (unweighted).
+    :type w: str, optional
+    :return: Squared poverty gap.
+    :rtype: float
+    """
+    gap = np.maximum(df[threshold] - df[income], 0)
+    sq_gap = gap ** 2
+    if w is None:
+        return sq_gap.sum()
+    return (sq_gap * df[w]).sum()

--- a/microdf/poverty.py
+++ b/microdf/poverty.py
@@ -36,7 +36,7 @@ def poverty_rate(
     pov = df[income] < df[threshold]
     if w is None:
         return pov.mean()
-    return (pov * w).sum() / w.sum()
+    return (pov * df[w]).sum() / df[w].sum()
 
 
 def deep_poverty_rate(
@@ -60,7 +60,7 @@ def deep_poverty_rate(
     pov = df[income] < df[threshold] / 2
     if w is None:
         return pov.mean()
-    return (pov * w).sum() / w.sum()
+    return (pov * df[w]).sum() / df[w].sum()
 
 
 def poverty_gap(
@@ -107,7 +107,7 @@ def squared_poverty_gap(
     :rtype: float
     """
     gap = np.maximum(df[threshold] - df[income], 0)
-    sq_gap = gap ** 2
+    sq_gap = np.power(gap, 2)
     if w is None:
         return sq_gap.sum()
     return (sq_gap * df[w]).sum()

--- a/microdf/tests/test_poverty.py
+++ b/microdf/tests/test_poverty.py
@@ -1,5 +1,6 @@
 import microdf as mdf
 
+import numpy as np
 import pandas as pd
 
 df = pd.DataFrame(
@@ -13,33 +14,40 @@ df = pd.DataFrame(
 
 def test_poverty_rate():
     # Unweighted
-    assert mdf.poverty_rate(df, "income", "threshold") == 3 / 4
+    assert np.allclose(mdf.poverty_rate(df, "income", "threshold"), 3 / 4)
     # Weighted
-    assert mdf.poverty_rate(df, "income", "threshold", "weight") == 6 / 10
+    assert np.allclose(
+        mdf.poverty_rate(df, "income", "threshold", "weight"), 6 / 10
+    )
 
 
 def test_deep_poverty_rate():
     # Unweighted
-    assert mdf.deep_poverty_rate(df, "income", "threshold") == 2 / 4
+    assert np.allclose(mdf.deep_poverty_rate(df, "income", "threshold"), 2 / 4)
     # Weighted
-    assert mdf.deep_poverty_rate(df, "income", "threshold", "weight") == 3 / 10
+    assert np.allclose(
+        mdf.deep_poverty_rate(df, "income", "threshold", "weight"), 3 / 10
+    )
 
 
 def test_poverty_gap():
     # Unweighted
-    assert mdf.poverty_gap(df, "income", "threshold") == 25 + 10 + 5
+    assert np.allclose(mdf.poverty_gap(df, "income", "threshold"), 25 + 10 + 5)
     # Weighted
-    assert mdf.poverty_gap(df, "income", "threshold", "weight") == (
-        25 * 1 + 10 * 2 + 5 * 3
+    assert np.allclose(
+        mdf.poverty_gap(df, "income", "threshold", "weight"),
+        25 * 1 + 10 * 2 + 5 * 3,
     )
 
 
 def test_squared_poverty_gap():
     # Unweighted
-    assert mdf.squared_poverty_gap(df, "income", "threshold") == (
-        25 ** 2 + 10 ** 2 + 5 ** 2
+    assert np.allclose(
+        mdf.squared_poverty_gap(df, "income", "threshold"),
+        25 ** 2 + 10 ** 2 + 5 ** 2,
     )
     # Weighted
-    assert mdf.squared_poverty_gap(df, "income", "threshold", "weight") == (
-        1 * (25 ** 2) + 2 * (10 ** 2) + 3 * (5 ** 2)
+    assert np.allclose(
+        mdf.squared_poverty_gap(df, "income", "threshold", "weight"),
+        1 * (25 ** 2) + 2 * (10 ** 2) + 3 * (5 ** 2),
     )

--- a/microdf/tests/test_poverty.py
+++ b/microdf/tests/test_poverty.py
@@ -1,0 +1,45 @@
+import microdf as mdf
+
+import pandas as pd
+
+df = pd.DataFrame(
+    {
+        "income": [-10, 0, 10, 20],
+        "threshold": [15, 10, 15, 10],
+        "weight": [1, 2, 3, 4],
+    }
+)
+
+
+def test_poverty_rate():
+    # Unweighted
+    assert mdf.poverty_rate(df, "income", "threshold") == 3 / 4
+    # Weighted
+    assert mdf.poverty_rate(df, "income", "threshold", "weight") == 6 / 10
+
+
+def test_deep_poverty_rate():
+    # Unweighted
+    assert mdf.deep_poverty_rate(df, "income", "threshold") == 2 / 4
+    # Weighted
+    assert mdf.deep_poverty_rate(df, "income", "threshold", "weight") == 3 / 10
+
+
+def test_poverty_gap():
+    # Unweighted
+    assert mdf.poverty_gap(df, "income", "threshold") == 25 + 10 + 5
+    # Weighted
+    assert mdf.poverty_gap(df, "income", "threshold", "weight") == (
+        25 * 1 + 10 * 2 + 5 * 3
+    )
+
+
+def test_squared_poverty_gap():
+    # Unweighted
+    assert mdf.squared_poverty_gap(df, "income", "threshold") == (
+        25 ** 2 + 10 ** 2 + 5 ** 2
+    )
+    # Weighted
+    assert mdf.squared_poverty_gap(df, "income", "threshold", "weight") == (
+        1 * (25 ** 2) + 2 * (10 ** 2) + 3 * (5 ** 2)
+    )


### PR DESCRIPTION
Adds the following functions, with tests:
* `poverty_rate`
* `deep_poverty_rate` (below half threshold)
* `poverty_gap`
* `squared_poverty_gap`

Each has the same interface: `f(df, income, threshold, w)`, e.g. `poverty_rate(asec, "spmtotres", "spmthresh", "marsupwt")`.

@ngpsu22 @nikhilwoodruff