### PR TITLE
Add MicroSeries and MicroDataFrame classes

### DIFF
--- a/microdf/__init__.py
+++ b/microdf/__init__.py
@@ -70,6 +70,7 @@ from .weighted import (
     weighted_quantile,
     weighted_sum,
 )
+from .generic import MicroDataFrame, MicroSeries
 
 name = "microdf"
 __version__ = "0.1.0"

--- a/microdf/__init__.py
+++ b/microdf/__init__.py
@@ -160,4 +160,7 @@ __all__ = [
     "weighted_median",
     "add_weighted_quantiles",
     "quantile_chg",
+    # generic.py
+    "MicroSeries",
+    "MicroDataFrame",
 ]

--- a/microdf/generic.py
+++ b/microdf/generic.py
@@ -1,0 +1,132 @@
+import numpy as np
+import pandas as pd
+
+class MicroSeries(pd.Series):
+    def __init__(self, *args, weights=None, **kwargs):
+        """A Series-inheriting class for weighted microdata.
+        Weights can be provided at initialisation, or using
+        set_weights.
+    
+        :param weights: Array of weights.
+        :type weights: np.array
+        """
+        super().__init__(*args, **kwargs)
+        self.weights = weights
+      
+    def _init_micro(self, weights=None):
+      self.weights = weights
+    
+    def set_weights(self, weights):
+        """Sets the weight values.
+        
+        :param weights: Array of weights.
+        :type weights: np.array.
+
+        :returns: A Pandas Series multiplying the MicroSeries by its weight.
+        """
+        self.weights = weights
+
+    def weight(self):
+        """Calculates the weighted value of the MicroSeries.
+
+        :returns: A Pandas Series multiplying the MicroSeries by its weight.
+        """
+        return self.multiply(self.weights)
+    
+    def sum(self):
+        """Calculates the weighted sum of the MicroSeries.
+
+        :returns: The weighted sum.
+        """
+        return self.weight().sum()
+    
+    def mean(self):
+        """Calculates the weighted mean of the MicroSeries
+
+        :returns: The weighted mean.
+        """
+        return np.average(self.values, weights=self.weights)
+    
+    def quantile(self, quantiles):
+        """Calculates weighted quantiles of the MicroSeries.
+
+        Doesn't exactly match unweighted quantiles of stacked values.
+        See stackoverflow.com/q/21844024#comment102342137_29677616.
+
+        :param quantiles: Array of quantiles to calculate.
+        :type quantiles: np.array
+
+        :return: Array of weighted quantiles.
+        :rtype: np.array
+        """
+        values = np.array(self.values)
+        quantiles = np.array(quantiles)
+        if self.weights is None:
+            sample_weight = np.ones(len(values))
+        else:
+            sample_weight = np.array(self.weights)
+        assert np.all(quantiles >= 0) and np.all(
+            quantiles <= 1
+        ), "quantiles should be in [0, 1]"
+        sorter = np.argsort(values)
+        values = values[sorter]
+        sample_weight = sample_weight[sorter]
+        weighted_quantiles = np.cumsum(sample_weight) - 0.5 * sample_weight
+        weighted_quantiles /= np.sum(sample_weight)
+        return np.interp(quantiles, weighted_quantiles, values)
+
+    def median(self):
+        """Calculates the weighted median of the MicroSeries.
+
+        :returns: The weighted median of a DataFrame's column.
+        """
+        return self.quantile(0.5)
+
+class MicroDataFrame(pd.DataFrame):
+  def __init__(self, *args, weights=None, **kwargs):
+    """A DataFrame-inheriting class for weighted microdata.
+    Weights can be provided at initialisation, or using set_weights
+    or set_weight_col.
+    
+    :param weights: Array of weights.
+    :type weights: np.array
+    """
+    super().__init__(*args, **kwargs)
+    self.weights = weights
+    self.weight_col = None
+
+  def _link_weights(self, column):
+    # self[column] = ... triggers __setitem__, which forces pd.Series
+    # this workaround avoids that
+    self[column].__class__ = MicroSeries
+    self[column]._init_micro(weights=self.weights)
+  
+  def _link_all_weights(self):
+    for column in self.columns:
+      if column != self.weight_col:
+        self._link_weights(column)
+  
+  def set_weights(self, weights):
+    """Sets the weights for the MicroDataFrame. If a 
+    string is received, it will be assumed to be the column 
+    name of the weight column.
+    
+    :param weights: Array of weights.
+    :type weights: np.array
+    """
+    if isinstance(weights, str):
+        self.set_weight_col(weights)
+    else:
+        self.weights = np.array(weights)
+        self._link_all_weights()
+
+  def set_weight_col(self, column):
+    """Sets the weights for the MicroDataFrame by 
+    specifying the name of the weight column.
+    
+    :param weights: Array of weights.
+    :type weights: np.array
+    """
+    self.weights = np.array(self[column])
+    self.weight_col = column
+    self._link_all_weights()

--- a/microdf/tests/test_generic.py
+++ b/microdf/tests/test_generic.py
@@ -1,4 +1,3 @@
-import pandas as pd
 import numpy as np
 import microdf as mdf
 
@@ -20,7 +19,7 @@ def test_sum():
     try:
         series.set_weights(w)
         assert False
-    except:
+    except Exception:
         pass
 
 
@@ -41,5 +40,5 @@ def test_mean():
     try:
         series.set_weights(w)
         assert False
-    except:
+    except Exception:
         pass

--- a/microdf/tests/test_generic.py
+++ b/microdf/tests/test_generic.py
@@ -1,0 +1,43 @@
+import pandas as pd
+import numpy as np
+import microdf as mdf
+
+def test_sum():
+    arr = np.array([0, 1, 1])
+    w = np.array([3, 0, 9])
+    series = mdf.MicroSeries(arr, weights=w)
+    assert series.sum() == (arr * w).sum()
+
+    arr = np.linspace(-20, 100, 100)
+    w = np.linspace(1, 3, 100)
+    series = mdf.MicroSeries(arr)
+    series.set_weights(w)
+    assert series.sum() == (arr * w).sum()
+
+    w = np.linspace(1, 3, 101)
+    series = mdf.MicroSeries(arr)
+    try:
+        series.set_weights(w)
+        assert False
+    except:
+        pass
+
+def test_mean():
+    arr = np.array([3, 0, 2])
+    w = np.array([4, 1, 1])
+    series = mdf.MicroSeries(arr, weights=w)
+    assert series.mean() == np.average(arr, weights=w)
+
+    arr = np.linspace(-20, 100, 100)
+    w = np.linspace(1, 3, 100)
+    series = mdf.MicroSeries(arr)
+    series.set_weights(w)
+    assert series.mean() == np.average(arr, weights=w)
+
+    w = np.linspace(1, 3, 101)
+    series = mdf.MicroSeries(arr)
+    try:
+        series.set_weights(w)
+        assert False
+    except:
+        pass

--- a/microdf/tests/test_generic.py
+++ b/microdf/tests/test_generic.py
@@ -2,6 +2,7 @@ import pandas as pd
 import numpy as np
 import microdf as mdf
 
+
 def test_sum():
     arr = np.array([0, 1, 1])
     w = np.array([3, 0, 9])
@@ -21,6 +22,7 @@ def test_sum():
         assert False
     except:
         pass
+
 
 def test_mean():
     arr = np.array([3, 0, 2])


### PR DESCRIPTION
Having classes that inherit and preserve key Pandas functionality, while overriding and adding microdf functions, might help reduce the learning curve for the package and allow users to treat the objects as if they contain the entire populations, abstracting away some of the microdata-specific implementations. 

In this small PR, I had a go at adding the classes ```MicroSeries```, which links a regular Series to a weight array and overrides core features to use the weights, and ```MicroDataFrame```, which holds multiple ```MicroSeries``` (or just ```Series```) objects, to ensure calculations across the ```MicroDataFrame``` use the weights where necessary.  Both inherit from their core counterparts, and the implementations seem to work without error, only one real workaround was needed (see the code). I also added some tests for the MicroSeries.

Thanks for reading - I'd be really open to any suggestions/comments!