### PR TITLE
Fix bugs and add partial groupby support

### DIFF
--- a/microdf/generic.py
+++ b/microdf/generic.py
@@ -99,6 +99,12 @@ class MicroSeries(pd.Series):
         gb.__class__ = MicroSeriesGroupBy
         gb.weights = pd.Series(self.weights).groupby(*args, **kwargs)
         return gb
+    
+    def _get_values(self, indexer):
+        try:
+            return MicroSeries(self._mgr.get_slice(indexer), weights=pd.Series(self.weights)._mgr.get_slice(indexer)).__finalize__(self)
+        except ValueError:
+            return np.asarray(self._values[indexer])
 
 class MicroSeriesGroupBy(pd.core.groupby.generic.SeriesGroupBy):
     def __init__(self, weights=None, *args, **kwargs):

--- a/microdf/generic.py
+++ b/microdf/generic.py
@@ -107,14 +107,14 @@ class MicroSeriesGroupBy(pd.core.groupby.generic.SeriesGroupBy):
         self.mean = self.weighted_agg(self.mean)
 
     def _weighted_agg(func):
-        def via_micro_series(row, fn):
-            return getattr(MicroSeries(row.a, weights=row.w), fn.__name__)()
+        def via_micro_series(row, fn, *args, **kwargs):
+            return getattr(MicroSeries(row.a, weights=row.w), fn.__name__)(*args, **kwargs)
 
         def _weighted_agg_fn(self, *args, **kwargs):
             arrays = self.apply(np.array)
             weights = self.weights.apply(np.array)
             df = pd.DataFrame(dict(a=arrays, w=weights))
-            result = df.agg(lambda row: via_micro_series(row, func), axis=1)
+            result = df.agg(lambda row: via_micro_series(row, func, *args, **kwargs), axis=1)
             return result
         return _weighted_agg_fn
     
@@ -131,8 +131,8 @@ class MicroSeriesGroupBy(pd.core.groupby.generic.SeriesGroupBy):
         return MicroSeries.mean(self)
 
     @_weighted_agg
-    def quantile(self):
-        return MicroSeries.quantile(self)
+    def quantile(self, quantiles):
+        return MicroSeries.quantile(self, quantiles)
 
     @_weighted_agg
     def median(self):

--- a/microdf/tests/test_generic.py
+++ b/microdf/tests/test_generic.py
@@ -1,6 +1,7 @@
 import numpy as np
 import microdf as mdf
 
+
 def test_df_init():
     arr = np.array([0, 1, 1])
     w = np.array([3, 0, 9])
@@ -18,12 +19,13 @@ def test_df_init():
     df.set_weight_col("w")
     assert df.a.mean() == np.average(arr, weights=w)
 
+
 def test_series_getitem():
     arr = np.array([0, 1, 1])
     w = np.array([3, 0, 9])
     s = mdf.MicroSeries(arr, weights=w)
     assert s[[1, 2]].sum() == np.sum(arr[[1, 2]] * w[[1, 2]])
-    
+
     assert s[1:3].sum() == np.sum(arr[1:3] * w[1:3])
 
 

--- a/microdf/tests/test_generic.py
+++ b/microdf/tests/test_generic.py
@@ -18,6 +18,14 @@ def test_df_init():
     df.set_weight_col("w")
     assert df.a.mean() == np.average(arr, weights=w)
 
+def test_series_getitem():
+    arr = np.array([0, 1, 1])
+    w = np.array([3, 0, 9])
+    s = mdf.MicroSeries(arr, weights=w)
+    assert s[[1, 2]].sum() == np.sum(arr[[1, 2]] * w[[1, 2]])
+    
+    assert s[1:3].sum() == np.sum(arr[1:3] * w[1:3])
+
 
 def test_sum():
     arr = np.array([0, 1, 1])

--- a/microdf/tests/test_generic.py
+++ b/microdf/tests/test_generic.py
@@ -1,6 +1,23 @@
 import numpy as np
 import microdf as mdf
 
+def test_df_init():
+    arr = np.array([0, 1, 1])
+    w = np.array([3, 0, 9])
+    df = mdf.MicroDataFrame({"a": arr}, weights=w)
+    assert df.a.mean() == np.average(arr, weights=w)
+
+    df = mdf.MicroDataFrame()
+    df["a"] = arr
+    df.set_weights(w)
+    assert df.a.mean() == np.average(arr, weights=w)
+
+    df = mdf.MicroDataFrame()
+    df["a"] = arr
+    df["w"] = w
+    df.set_weight_col("w")
+    assert df.a.mean() == np.average(arr, weights=w)
+
 
 def test_sum():
     arr = np.array([0, 1, 1])


### PR DESCRIPTION
Should fix #165 , I no longer get any crashes.

GroupBys seem to be slightly complicating things, because the groupby objects returned when calling df.groupby or series.groupby don't directly call the already overridden series and dataframe functions. So this adds a MicroSeriesGroupBy class which, intruding as little as possible onto existing groupby functionality, intercepts the calls to median, mean, etc. and passes onto the overriden functions. As for dataframes, the df.groupby function now returns a dataframegroupby object, but the internal seriesgroupby objects have been cast to MicroSeriesGroupBy objects so they use weights. This means:

- Series groupbys should work as normal (but using weights)
- DataFrame groupbys don't entirely work yet:
  - df.groupby(...)[col] will return a series groupby object, so that works.
  - df.groupby(...).mean()[col] will work, but won't use weighted functions, because the mean() function returns a DataFrameGroupBy object. We might need to write a MicroDataFrameGroupBy class for this that intercepts the weighted functions like mean, etc.