### PR TITLE
Add mdf.concat to mirror pd.concat and preserve weights

### DIFF
--- a/microdf/__init__.py
+++ b/microdf/__init__.py
@@ -1,6 +1,7 @@
 from .agg import agg, combine_base_reform, pctchg_base_reform
 from .chart_utils import dollar_format, currency_format
 from .charts import quantile_chg_plot, quantile_pct_chg_plot
+from .concat import concat
 from .constants import (
     BENS,
     ECI_REMOVE_COLS,
@@ -86,6 +87,8 @@ __all__ = [
     # charts.py
     "quantile_chg_plot",
     "quantile_pct_chg_plot",
+    # concat.py
+    "concat",
     # constants.py
     "BENS",
     "ECI_REMOVE_COLS",

--- a/microdf/concat.py
+++ b/microdf/concat.py
@@ -1,0 +1,26 @@
+import pandas as pd
+import inspect
+import microdf as mdf
+
+
+def concat(*args, **kwargs):
+    """Concatenates MicroDataFrame objects, preserving weights.
+    If concatenating horizontally, the first set of weights are used.
+    All args and kwargs are passed to pd.concat.
+
+    :return: MicroDataFrame with concatenated weights.
+    :rtype: mdf.MicroDataFrame
+    """
+    # Extract args with respect to pd.concat.
+    pd_args = inspect.getcallargs(pd.concat, *args, **kwargs)
+    objs = pd_args["objs"]
+    axis = pd_args["axis"]
+    # Create result, starting with pd.concat.
+    res = mdf.MicroDataFrame(pd.concat(*args, **kwargs))
+    # Assign weights depending on axis.
+    if axis == 0:
+        res.weights = pd.concat([obj.weights for obj in objs])
+    else:
+        # If concatenating horizontally, use the first set of weights.
+        res.weights = objs[0].weights
+    return res

--- a/microdf/tests/test_generic.py
+++ b/microdf/tests/test_generic.py
@@ -1,6 +1,7 @@
 from microdf.generic import MicroDataFrame
 import numpy as np
 import microdf as mdf
+import pandas as pd
 
 
 def test_df_init():
@@ -99,3 +100,22 @@ def test_unweighted_groupby():
 def test_multiple_groupby():
     df = mdf.MicroDataFrame({"x": [1, 2], "y": [3, 4], "z": [5, 6]})
     assert (df.groupby(["x", "y"]).z.sum() == np.array([5, 6])).all()
+
+
+def test_concat():
+    df1 = mdf.MicroDataFrame({"x": [1, 2]}, weights=[3, 4])
+    df2 = mdf.MicroDataFrame({"y": [5, 6]}, weights=[7, 8])
+    # Verify that pd.concat returns DataFrame (probably no way to fix this).
+    pd_long = pd.concat([df1, df2])
+    assert isinstance(pd_long, pd.DataFrame)
+    assert not isinstance(pd_long, mdf.MicroDataFrame)
+    # Verify that mdf.concat works.
+    mdf_long = mdf.concat([df1, df2])
+    assert isinstance(mdf_long, mdf.MicroDataFrame)
+    # Weights should be preserved.
+    assert mdf_long.weights == pd.concat([df1.weights, df2.weights])
+    # Verify it works horizontally too (take the first set of weights).
+    mdf_wide = mdf.concat([df1, df2], axis=1)
+    assert isinstance(mdf_wide, mdf.MicroDataFrame)
+    assert mdf_wide.weights == df1.weights
+

--- a/microdf/tests/test_generic.py
+++ b/microdf/tests/test_generic.py
@@ -118,4 +118,3 @@ def test_concat():
     mdf_wide = mdf.concat([df1, df2], axis=1)
     assert isinstance(mdf_wide, mdf.MicroDataFrame)
     assert mdf_wide.weights.equals(df1.weights)
-

--- a/microdf/tests/test_generic.py
+++ b/microdf/tests/test_generic.py
@@ -113,9 +113,9 @@ def test_concat():
     mdf_long = mdf.concat([df1, df2])
     assert isinstance(mdf_long, mdf.MicroDataFrame)
     # Weights should be preserved.
-    assert mdf_long.weights == pd.concat([df1.weights, df2.weights])
+    assert mdf_long.weights.equals(pd.concat([df1.weights, df2.weights]))
     # Verify it works horizontally too (take the first set of weights).
     mdf_wide = mdf.concat([df1, df2], axis=1)
     assert isinstance(mdf_wide, mdf.MicroDataFrame)
-    assert mdf_wide.weights == df1.weights
+    assert mdf_wide.weights.equals(df1.weights)
 


### PR DESCRIPTION
Fixes #181

`mdf.concat` can be invoked identically to `pd.concat`. The `objs` required arg should be a list of `MicroDataFrame`s, and the result (unlike `pd.concat`) will be a `MicroDataFrame` that preserves the weights. Horizontal concatenation preserves the weights of `objs[0]`.