### PR TITLE
Implement {MicroDataFrame,MicroSeries}.{copy,equals}, and fix MicroDataFrame column subsetting

### DIFF
--- a/microdf/generic.py
+++ b/microdf/generic.py
@@ -593,7 +593,7 @@ class MicroDataFrame(pd.DataFrame):
     def __getitem__(self, key):
         result = super().__getitem__(key)
         if isinstance(result, pd.DataFrame):
-            weights = self.weights.__getitem__(key)
+            weights = self.weights
             return MicroDataFrame(result, weights=weights)
         return result
 

--- a/microdf/generic.py
+++ b/microdf/generic.py
@@ -3,7 +3,6 @@ from functools import wraps
 import warnings
 import numpy as np
 import pandas as pd
-import copy
 
 
 class MicroSeries(pd.Series):
@@ -260,8 +259,10 @@ class MicroSeries(pd.Series):
         gb.weights = pd.Series(self.weights).groupby(*args, **kwargs)
         return gb
 
-    def copy(self):
-        return copy.deepcopy(self)
+    def copy(self, deep=True):
+        res = super().copy(deep)
+        res = MicroSeries(res, weights=self.weights.copy(deep))
+        return res
 
     def equals(self, other) -> bool:
         equal_values = super().equals(other)
@@ -620,8 +621,10 @@ class MicroDataFrame(pd.DataFrame):
         res = MicroDataFrame(res, weights=self.weights)
         return res
 
-    def copy(self):
-        return copy.deepcopy(self)
+    def copy(self, deep=True):
+        res = super().copy(deep)
+        res = MicroDataFrame(res, weights=self.weights.copy(deep))
+        return res
 
     def equals(self, other) -> bool:
         equal_values = super().equals(other)

--- a/microdf/generic.py
+++ b/microdf/generic.py
@@ -611,8 +611,8 @@ class MicroDataFrame(pd.DataFrame):
         res = MicroDataFrame(res, weights=self.weights)
         return res
 
-    def copy(self, *args, **kwargs):
-        res = super().copy(*args, **kwargs)
+    def copy(self, deep=True):
+        res = super().copy(deep)
         res = MicroDataFrame(res, weights=self.weights)
         return res
 

--- a/microdf/generic.py
+++ b/microdf/generic.py
@@ -623,6 +623,9 @@ class MicroDataFrame(pd.DataFrame):
 
     def copy(self, deep=True):
         res = super().copy(deep)
+        # This changes the original columns to Series. Undo it:
+        for col in self.columns:
+            self[col] = MicroSeries(self[col])
         res = MicroDataFrame(res, weights=self.weights.copy(deep))
         return res
 

--- a/microdf/generic.py
+++ b/microdf/generic.py
@@ -1,8 +1,9 @@
-import numpy as np
-import pandas as pd
 from typing import Callable, Union
 from functools import wraps
 import warnings
+import numpy as np
+import pandas as pd
+import copy
 
 
 class MicroSeries(pd.Series):
@@ -259,10 +260,8 @@ class MicroSeries(pd.Series):
         gb.weights = pd.Series(self.weights).groupby(*args, **kwargs)
         return gb
 
-    def copy(self, deep=True):
-        res = super().copy(deep)
-        res = MicroSeries(res, weights=self.weights.copy(deep))
-        return res
+    def copy(self):
+        return copy.deepcopy(self)
 
     def equals(self, other) -> bool:
         equal_values = super().equals(other)
@@ -621,10 +620,8 @@ class MicroDataFrame(pd.DataFrame):
         res = MicroDataFrame(res, weights=self.weights)
         return res
 
-    def copy(self, deep=True):
-        res = super().copy(deep)
-        res = MicroDataFrame(res, weights=self.weights.copy(deep))
-        return res
+    def copy(self):
+        return copy.deepcopy(self)
 
     def equals(self, other) -> bool:
         equal_values = super().equals(other)

--- a/microdf/generic.py
+++ b/microdf/generic.py
@@ -259,6 +259,16 @@ class MicroSeries(pd.Series):
         gb.weights = pd.Series(self.weights).groupby(*args, **kwargs)
         return gb
 
+    def copy(self, deep=True):
+        res = super().copy(deep)
+        res = MicroSeries(res, weights=self.weights.copy(deep))
+        return res
+
+    def equals(self, other) -> bool:
+        equal_values = super().equals(other)
+        equal_weights = self.weights.equals(other.weights)
+        return equal_values and equal_weights
+
     def __getitem__(self, key):
         result = super().__getitem__(key)
         if isinstance(result, pd.Series):
@@ -613,13 +623,13 @@ class MicroDataFrame(pd.DataFrame):
 
     def copy(self, deep=True):
         res = super().copy(deep)
-        res = MicroDataFrame(res, weights=self.weights)
+        res = MicroDataFrame(res, weights=self.weights.copy(deep))
         return res
 
     def equals(self, other) -> bool:
-        equal_df = super().equals(other)
+        equal_values = super().equals(other)
         equal_weights = self.weights.equals(other.weights)
-        return equal_df and equal_weights
+        return equal_values and equal_weights
 
     def groupby(self, by: Union[str, list], *args, **kwargs):
         """Returns a GroupBy object with MicroSeriesGroupBy objects for each column

--- a/microdf/generic.py
+++ b/microdf/generic.py
@@ -611,10 +611,15 @@ class MicroDataFrame(pd.DataFrame):
         res = MicroDataFrame(res, weights=self.weights)
         return res
 
-    def copy(self, *args, **kwargs) -> MicroDataFrame:
+    def copy(self, *args, **kwargs):
         res = super().copy(*args, **kwargs)
         res = MicroDataFrame(res, weights=self.weights)
         return res
+
+    def equals(self, other) -> bool:
+        equal_df = super().equals(other)
+        equal_weights = self.weights.equals(other.weights)
+        return equal_df and equal_weights
 
     def groupby(self, by: Union[str, list], *args, **kwargs):
         """Returns a GroupBy object with MicroSeriesGroupBy objects for each column

--- a/microdf/generic.py
+++ b/microdf/generic.py
@@ -611,6 +611,11 @@ class MicroDataFrame(pd.DataFrame):
         res = MicroDataFrame(res, weights=self.weights)
         return res
 
+    def copy(self, *args, **kwargs) -> MicroDataFrame:
+        res = super().copy(*args, **kwargs)
+        res = MicroDataFrame(res, weights=self.weights)
+        return res
+
     def groupby(self, by: Union[str, list], *args, **kwargs):
         """Returns a GroupBy object with MicroSeriesGroupBy objects for each column
 

--- a/microdf/tests/test_generic.py
+++ b/microdf/tests/test_generic.py
@@ -152,3 +152,14 @@ def test_rank():
 
     s = mdf.MicroSeries([2, 1, 3], weights=[5, 4, 6])
     assert np.array_equal(s.rank().values, [9, 4, 15])
+
+
+def test_subset():
+    df = mdf.MicroDataFrame(
+        {"x": [1, 2], "y": [3, 4], "z": [5, 6]}, weights=[7, 8]
+    )
+    df_no_z = mdf.MicroDataFrame({"x": [1, 2], "y": [3, 4]}, weights=[7, 8])
+    assert df[["x", "y"]].equals(df_no_z)
+    df_no_z_diff_weights = df_no_z.copy(deep=True)
+    df_no_z_diff_weights.weights += 1
+    assert not df[["x", "y"]].equals(df_no_z_diff_weights)

--- a/microdf/tests/test_generic.py
+++ b/microdf/tests/test_generic.py
@@ -158,8 +158,8 @@ def test_copy_equals():
     d = mdf.MicroDataFrame(
         {"x": [1, 2], "y": [3, 4], "z": [5, 6]}, weights=[7, 8]
     )
-    d_copy = d.copy(deep=True)
-    d_copy_diff_weights = d_copy.copy(deep=True)
+    d_copy = d.copy()
+    d_copy_diff_weights = d_copy.copy()
     d_copy_diff_weights.weights *= 2
     assert d.equals(d_copy)
     assert not d.equals(d_copy_diff_weights)
@@ -171,6 +171,6 @@ def test_subset():
     )
     df_no_z = mdf.MicroDataFrame({"x": [1, 2], "y": [3, 4]}, weights=[7, 8])
     assert df[["x", "y"]].equals(df_no_z)
-    df_no_z_diff_weights = df_no_z.copy(deep=True)
+    df_no_z_diff_weights = df_no_z.copy()
     df_no_z_diff_weights.weights += 1
     assert not df[["x", "y"]].equals(df_no_z_diff_weights)

--- a/microdf/tests/test_generic.py
+++ b/microdf/tests/test_generic.py
@@ -163,6 +163,9 @@ def test_copy_equals():
     d_copy_diff_weights.weights *= 2
     assert d.equals(d_copy)
     assert not d.equals(d_copy_diff_weights)
+    # Same for a MicroSeries.
+    assert d.x.equals(d_copy.x)
+    assert not d.x.equals(d_copy_diff_weights.x)
 
 
 def test_subset():

--- a/microdf/tests/test_generic.py
+++ b/microdf/tests/test_generic.py
@@ -154,6 +154,17 @@ def test_rank():
     assert np.array_equal(s.rank().values, [9, 4, 15])
 
 
+def test_copy_equals():
+    d = mdf.MicroDataFrame(
+        {"x": [1, 2], "y": [3, 4], "z": [5, 6]}, weights=[7, 8]
+    )
+    d_copy = d.copy(deep=True)
+    d_copy_diff_weights = d_copy.copy(deep=True)
+    d_copy_diff_weights.weights *= 2
+    assert d.equals(d_copy)
+    assert not d.equals(d_copy_diff_weights)
+
+
 def test_subset():
     df = mdf.MicroDataFrame(
         {"x": [1, 2], "y": [3, 4], "z": [5, 6]}, weights=[7, 8]


### PR DESCRIPTION
This PR:
* Fixes `MicroDataFrame[[cols]]` (fixes #192)
* Implements `equals` in `MicroDataFrame` and `MicroSeries` (fixes #201)
* Implements `copy` in `MicroDataFrame` and `MicroSeries` (fixes #202 and fixes #206)

One test currently fails due to an odd bug I'm stumped on (#206). @nikhilwoodruff any ideas?
```
In [43]: d = mdf.MicroDataFrame({"x": [1, 2]}, weights=[3, 4])

In [44]: d.x.__class__
Out[44]: microdf.generic.MicroSeries

In [45]: d2 = d.copy()

In [46]: d.x.__class__
Out[46]: pandas.core.series.Series
```