### PR TITLE
Prevent floating-point error in decile calculation

### DIFF
--- a/microdf/generic.py
+++ b/microdf/generic.py
@@ -251,23 +251,24 @@ class MicroSeries(pd.Series):
         ranks = np.array(self.weights.values)[order].cumsum()[inverse_order]
         if pct:
             ranks /= self.weights.values.sum()
+            np.where(ranks > 1.0, 1.0, ranks)
         return pd.Series(ranks, index=self.index)
 
     @vector_function
     def decile_rank(self):
-        return MicroSeries(np.ceil(self.rank(pct=True) * 10))
+        return MicroSeries(np.minimum(np.ceil(self.rank(pct=True) * 10), 10))
 
     @vector_function
     def quintile_rank(self):
-        return MicroSeries(np.ceil(self.rank(pct=True) * 5))
+        return MicroSeries(np.minimum(np.ceil(self.rank(pct=True) * 5), 5))
 
     @vector_function
     def quartile_rank(self):
-        return MicroSeries(np.ceil(self.rank(pct=True) * 4))
+        return MicroSeries(np.minimum(np.ceil(self.rank(pct=True) * 4), 4))
 
     @vector_function
     def percentile_rank(self):
-        return MicroSeries(np.ceil(self.rank(pct=True) * 100))
+        return MicroSeries(np.minimum(np.ceil(self.rank(pct=True) * 100), 100))
 
     def groupby(self, *args, **kwargs):
         gb = super().groupby(*args, **kwargs)


### PR DESCRIPTION
Fixes #234.

Unfortunately, the original intended implementation of just attempting to round erroneously high values in `rank()` was not sufficient, so this also adds the use of `np.minimum()` to each of the -ile functions to ensure no value exceeds their intended max.

I have not added tests, as I am unfamiliar with the testing protocol of this package. I am happy to do so, but am unsure how to simulate the floating point error necessary to reproduce this bug, other than adding a large dataset that actively triggers it, then testing against that. I am happy to do so, if desired.