### PR TITLE
Add conditional imports for heavier packages

### DIFF
--- a/microdf/chart_utils.py
+++ b/microdf/chart_utils.py
@@ -20,7 +20,9 @@ def currency_format(currency="USD", suffix=""):
         import matplotlib as mpl
     except ImportError:
         raise ImportError(
-            "The function you've called requires extra dependencies. Please install microdf with the 'charts' extra by running 'pip install microdf[charts]'"
+            "The function you've called requires extra dependencies. " +
+            "Please install microdf with the 'charts' extra by running " +
+            "'pip install microdf[charts]'"
         )
 
     prefix = {"USD": "$", "GBP": "£"}[currency]

--- a/microdf/chart_utils.py
+++ b/microdf/chart_utils.py
@@ -1,6 +1,3 @@
-import matplotlib as mpl
-
-
 def dollar_format(suffix=""):
     """Dollar formatter for matplotlib.
 
@@ -19,6 +16,12 @@ def currency_format(currency="USD", suffix=""):
     :returns: FuncFormatter.
 
     """
+    try:
+        import matplotlib as mpl
+    except ImportError:
+        raise ImportError(
+            "The function you've called requires extra dependencies. Please install microdf with the 'charts' extra by running 'pip install microdf[charts]'"
+        )
 
     prefix = {"USD": "$", "GBP": "£"}[currency]
 

--- a/microdf/charts.py
+++ b/microdf/charts.py
@@ -22,7 +22,9 @@ def quantile_pct_chg_plot(df1, df2, col1, col2, w1=None, w2=None, q=None):
         import matplotlib.pyplot as plt
     except ImportError:
         raise ImportError(
-            "The function you've called requires extra dependencies. Please install microdf with the 'charts' extra by running 'pip install microdf[charts]'"
+            "The function you've called requires extra dependencies. " +
+            "Please install microdf with the 'charts' extra by running " +
+            "'pip install microdf[charts]'"
         )
 
     if q is None:

--- a/microdf/charts.py
+++ b/microdf/charts.py
@@ -1,5 +1,3 @@
-import matplotlib as mpl
-import matplotlib.pyplot as plt
 import numpy as np
 
 import microdf as mdf
@@ -20,6 +18,8 @@ def quantile_pct_chg_plot(df1, df2, col1, col2, w1=None, w2=None, q=None):
     """
     try:
         import seaborn as sns
+        import matplotlib as mpl
+        import matplotlib.pyplot as plt
     except ImportError:
         raise ImportError(
             "The function you've called requires extra dependencies. Please install microdf with the 'charts' extra by running 'pip install microdf[charts]'"

--- a/microdf/charts.py
+++ b/microdf/charts.py
@@ -1,7 +1,6 @@
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
-import seaborn as sns
 
 import microdf as mdf
 
@@ -19,6 +18,13 @@ def quantile_pct_chg_plot(df1, df2, col1, col2, w1=None, w2=None, q=None):
     :returns: Axis.
 
     """
+    try:
+        import seaborn as sns
+    except ImportError:
+        raise ImportError(
+            "The function you've called requires extra dependencies. Please install microdf with the 'charts' extra by running 'pip install microdf[charts]'"
+        )
+
     if q is None:
         q = np.arange(0.1, 1, 0.1)
     # Calculate weighted quantiles.

--- a/microdf/style.py
+++ b/microdf/style.py
@@ -1,6 +1,5 @@
 import matplotlib as mpl
 import matplotlib.font_manager as fm
-import seaborn as sns
 
 
 TITLE_COLOR = "#212121"
@@ -16,6 +15,12 @@ def set_plot_style(dpi: int = DPI):
         (200).
     :type dpi: int, optional
     """
+    try:
+        import seaborn as sns
+    except ImportError:
+        raise ImportError(
+            "The function you've called requires extra dependencies. Please install microdf with the 'charts' extra by running 'pip install microdf[charts]'"
+        )
 
     sns.set_style("white")
 

--- a/microdf/style.py
+++ b/microdf/style.py
@@ -1,7 +1,3 @@
-import matplotlib as mpl
-import matplotlib.font_manager as fm
-
-
 TITLE_COLOR = "#212121"
 AXIS_COLOR = "#757575"
 GRID_COLOR = "#eeeeee"  # Previously lighter #f5f5f5.
@@ -17,6 +13,8 @@ def set_plot_style(dpi: int = DPI):
     """
     try:
         import seaborn as sns
+        import matplotlib as mpl
+        import matplotlib.font_manager as fm
     except ImportError:
         raise ImportError(
             "The function you've called requires extra dependencies. Please install microdf with the 'charts' extra by running 'pip install microdf[charts]'"

--- a/microdf/style.py
+++ b/microdf/style.py
@@ -17,7 +17,9 @@ def set_plot_style(dpi: int = DPI):
         import matplotlib.font_manager as fm
     except ImportError:
         raise ImportError(
-            "The function you've called requires extra dependencies. Please install microdf with the 'charts' extra by running 'pip install microdf[charts]'"
+            "The function you've called requires extra dependencies. " +
+            "Please install microdf with the 'charts' extra by running " +
+            "'pip install microdf[charts]'"
         )
 
     sns.set_style("white")

--- a/setup.py
+++ b/setup.py
@@ -10,12 +10,16 @@ setup(
     license="MIT",
     packages=["microdf"],
     install_requires=[
-        "matplotlib",
-        "matplotlib-label-lines",
         "numpy",
         "pandas",
-        "seaborn",
     ],
-    extras_require={"taxcalc": ["taxcalc"]},
+    extras_require={
+      "taxcalc": ["taxcalc"],
+      "charts": [
+        "seaborn",
+        "matplotlib",
+        "matplotlib-label-lines"
+      ]
+    },
     zip_safe=False,
 )


### PR DESCRIPTION
Fixes #236.

This adds conditional imports for `matplotlib` and `seaborn` for the few relevant functions where they are necessary. It also adds a `[charts]` install option to `setup.py` to enable the install of these, and uses try/except blocks to ensure the packages are installed.

This was tested locally by manually importing and running tests from `-core` and `-us` against.

Following the merging of this, I intend to do the following:
* Tag as v0.4.0
* Add a corresponding GitHub release
* Build a distribution locally via Twine
* Release to PyPI manually (once granted access)
* Open PR in `-core` removing the duplicative `microdf` code from it and installing this version
* Open PRs in `-us` and `-uk` to upgrade to this version, as most of their code does not use `-core`'s duplicative version of `microdf`